### PR TITLE
Add setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# AppointNew Setup
+
+This repository currently contains a simple setup script for installing the
+Flutter SDK along with Dart. The tasks are outlined below.
+
+## Tasks
+
+1. **Setting up Flutter**  
+   Run `setup.sh` to install Flutter and its dependencies. The script performs
+   the following steps:
+   - Updates package lists and installs prerequisites.
+   - Clones the Flutter repository into `/opt/flutter`.
+   - Adds Flutter (and its bundled Dart) to `PATH`.
+   - Optionally verifies the installation by printing version information.
+
+2. **Verifying Installation**  
+   After running the setup script, you can verify that Flutter and Dart are on
+   the `PATH`:
+
+   ```bash
+   which flutter
+   which dart
+   flutter --version
+   dart --version
+   ```
+
+## Files Added
+
+- `setup.sh` – Bash script used to install Flutter and verify that the SDK is
+  correctly installed.
+
+The repository originally contained only `.gitignore` and `LICENSE` files.
+This README and `setup.sh` have been added to document and automate the
+initial setup process.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# 1. Update package lists and install prerequisites
+apt-get update
+apt-get install -y curl git unzip xz-utils zip libglu1-mesa
+
+# 2. Clone the Flutter repository into /opt/flutter
+git clone https://github.com/flutter/flutter.git /opt/flutter
+
+# 3. Add Flutter (and its bundled Dart) to PATH
+export PATH="/opt/flutter/bin:$PATH"
+
+# 4. (Optional) Verify that flutter/dart is working
+flutter --version
+dart --version


### PR DESCRIPTION
## Summary
- add a `setup.sh` script for installing Flutter
- document setup and verification tasks in new README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68419f0739cc8324a77dff3b5f5c22de