### PR TITLE
Add offline Flutter/Dart setup script

### DIFF
--- a/setup_flutter.sh
+++ b/setup_flutter.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'echo "Error: Flutter and Dart installation failed." >&2' ERR
+
+ARCHIVE="flutter_sdk.tar.xz"
+SDK_DIR="/workspace/flutter_sdk"
+
+if [[ ! -f "${ARCHIVE}" ]]; then
+  echo "Error: ${ARCHIVE} not found in $(pwd)." >&2
+  exit 1
+fi
+
+mkdir -p "${SDK_DIR}"
+tar -xf "${ARCHIVE}" -C "${SDK_DIR}"
+
+export PATH="${SDK_DIR}/bin:${SDK_DIR}/bin/cache/dart-sdk/bin:${PATH}"
+
+which flutter
+which dart
+flutter --version
+dart --version
+
+echo "Flutter and Dart installation succeeded."
+


### PR DESCRIPTION
## Summary
- add `setup_flutter.sh` script for offline Flutter and Dart installation

## Testing
- `bash -n setup_flutter.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841b157c6988324baeb747c65ae029a