### PR TITLE
Add appointment service and repository

### DIFF
--- a/lib/repositories/appointment_repository.dart
+++ b/lib/repositories/appointment_repository.dart
@@ -1,0 +1,29 @@
+import '../models/appointment.dart';
+import '../services/appointment_service.dart';
+
+/// AppointmentRepository wraps the AppointmentService and provides
+/// higher-level methods for fetching and adding appointments.
+class AppointmentRepository {
+  final AppointmentService _service;
+
+  /// Constructor accepts an instance of AppointmentService.
+  AppointmentRepository(this._service);
+
+  /// Returns all appointments by delegating to the service.
+  Future<List<Appointment>> getAllAppointments() async {
+    try {
+      return await _service.fetchAppointments();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// Adds a new appointment by delegating to the service.
+  Future<Appointment> addAppointment(Appointment appointment) async {
+    try {
+      return await _service.createAppointment(appointment);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/appointment.dart';
+
+/// AppointmentService is responsible for performing HTTP calls
+/// to fetch and create appointments via a REST API using JSON.
+class AppointmentService {
+  final String baseUrl;
+
+  /// Constructor accepts the base URL of the server.
+  AppointmentService({required this.baseUrl});
+
+  /// Fetches all appointments from the server endpoint: GET {baseUrl}/appointments
+  Future<List<Appointment>> fetchAppointments() async {
+    final response = await http.get(Uri.parse('$baseUrl/appointments'));
+
+    if (response.statusCode == 200) {
+      final List<dynamic> decoded = json.decode(response.body) as List<dynamic>;
+      return decoded.map((jsonMap) => Appointment.fromJson(jsonMap)).toList();
+    } else {
+      throw Exception('Failed to load appointments (${response.statusCode})');
+    }
+  }
+
+  /// Creates a new appointment on the server with POST {baseUrl}/appointments
+  Future<Appointment> createAppointment(Appointment appointment) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl/appointments'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode(appointment.toJson()),
+    );
+
+    if (response.statusCode == 201) {
+      final Map<String, dynamic> decoded = json.decode(response.body) as Map<String, dynamic>;
+      return Appointment.fromJson(decoded);
+    } else {
+      throw Exception('Failed to create appointment (${response.statusCode})');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AppointmentService` with REST API calls
- implement `AppointmentRepository` wrapping the service

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5b3d1288324b285c2068a534c1b