### PR TITLE
Implement AppointmentProvider

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -1,0 +1,1 @@
+class Appointment {}

--- a/lib/providers/appointment_provider.dart
+++ b/lib/providers/appointment_provider.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../models/appointment.dart';
+import '../services/appointment_service.dart';
+
+class AppointmentProvider extends ChangeNotifier {
+  final AppointmentService _service;
+
+  List<Appointment> _appointments = [];
+  bool _isLoading = false;
+  bool _hasError = false;
+  String _errorMessage = '';
+
+  AppointmentProvider(this._service) {
+    loadAppointments();
+  }
+
+  List<Appointment> get appointments => _appointments;
+  bool get isLoading => _isLoading;
+  bool get hasError => _hasError;
+  String get errorMessage => _errorMessage;
+
+  Future<void> loadAppointments() async {
+    _isLoading = true;
+    _hasError = false;
+    notifyListeners();
+    try {
+      _appointments = await _service.fetchAppointments();
+      _errorMessage = '';
+    } catch (e) {
+      _hasError = true;
+      _errorMessage = e.toString();
+    }
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> refreshAppointments() async {
+    await loadAppointments();
+  }
+
+  Future<bool> addAppointment(Appointment appointment) async {
+    try {
+      final newAppointment = await _service.createAppointment(appointment);
+      _appointments.insert(0, newAppointment);
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _hasError = true;
+      _errorMessage = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  void clearError() {
+    _hasError = false;
+    _errorMessage = '';
+    notifyListeners();
+  }
+}

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -1,0 +1,6 @@
+import '../models/appointment.dart';
+
+abstract class AppointmentService {
+  Future<List<Appointment>> fetchAppointments();
+  Future<Appointment> createAppointment(Appointment appointment);
+}


### PR DESCRIPTION
## Summary
- add minimal `Appointment` model
- add `AppointmentService` abstraction
- implement `AppointmentProvider` with loading and error handling

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: dart not found)*
- `dart analyze .` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d798745c8324b2c2f1dd3ade3ef2