### PR TITLE
Add Flutter main entry file

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/appointment_provider.dart';
+import 'screens/appointment_list_screen.dart';
+import 'screens/appointment_add_screen.dart';
+import 'screens/appointment_edit_screen.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<AppointmentProvider>(
+      create: (_) => AppointmentProvider(),
+      child: MaterialApp(
+        title: 'Appointment App',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: const AppointmentListScreen(),
+        routes: {
+          '/add': (_) => const AppointmentAddScreen(),
+          '/edit': (_) => const AppointmentEditScreen(),
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add skeleton `lib/main.dart` that sets up provider and routes

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f4d712448324b765425ca38e2136