### PR TITLE
Add appointment details screen

### DIFF
--- a/lib/features/personal_scheduler/appointment_details_screen.dart
+++ b/lib/features/personal_scheduler/appointment_details_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'appointments_provider.dart';
+import 'domain/appointment.dart';
+
+class AppointmentDetailsScreen extends StatelessWidget {
+  const AppointmentDetailsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final id = GoRouterState.of(context).params['id']!;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Appointment Details'),
+      ),
+      body: Consumer(
+        builder: (context, ref, _) {
+          final appointmentAsync = ref.watch(appointmentsProvider(id));
+          return appointmentAsync.when(
+            data: (appointment) {
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      appointment.title,
+                      style: Theme.of(context).textTheme.headline6,
+                    ),
+                    const SizedBox(height: 8),
+                    Text('Date: ${appointment.date}'),
+                    const SizedBox(height: 4),
+                    Text('Time: ${appointment.time}'),
+                    const SizedBox(height: 16),
+                    Text(appointment.description),
+                    const SizedBox(height: 24),
+                    Center(
+                      child: ElevatedButton(
+                        onPressed: () => context.push('/personal/edit/$id'),
+                        child: const Text('Edit'),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (err, stack) => Center(child: Text('Error: $err')),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/test/features/personal_scheduler/appointment_details_screen_test.dart
+++ b/test/features/personal_scheduler/appointment_details_screen_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:appointnew/features/personal_scheduler/appointment_details_screen.dart';
+import 'package:appointnew/features/personal_scheduler/appointments_provider.dart';
+import 'package:appointnew/features/personal_scheduler/domain/appointment.dart';
+
+void main() {
+  testWidgets('AppointmentDetailsScreen displays appointment data', (tester) async {
+    const testAppointment = Appointment(
+      id: '1',
+      title: 'Test',
+      date: '2023-01-01',
+      time: '10:00 AM',
+      description: 'Desc',
+    );
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/personal/details/:id',
+          builder: (context, state) => const AppointmentDetailsScreen(),
+        ),
+      ],
+      initialLocation: '/personal/details/1',
+    );
+
+    final container = ProviderContainer(overrides: [
+      appointmentsProvider('1').overrideWithValue(const AsyncValue.data(testAppointment)),
+    ]);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.pump();
+    expect(find.text('Test'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add new appointment details screen
- scaffold widget test stub for the new screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446a3c824c83248fb13ca10717144e