### PR TITLE
Add appointment details screen with test stub

### DIFF
--- a/lib/features/personal_scheduler/appointment_details_screen.dart
+++ b/lib/features/personal_scheduler/appointment_details_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'appointments_provider.dart';
+import 'domain/appointment.dart';
+
+class AppointmentDetailsScreen extends ConsumerWidget {
+  const AppointmentDetailsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Read appointment id from route parameters
+    final id = context.goRouter
+        .namedLocation('personal/details')
+        .params['id'];
+
+    final appointmentAsync = ref.watch(appointmentsProvider(id));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Appointment Details'),
+      ),
+      body: appointmentAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Text('Error: $error'),
+        ),
+        data: (appointment) => SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                appointment.title,
+                style: Theme.of(context).textTheme.headline6,
+              ),
+              const SizedBox(height: 8),
+              Text(appointment.date.toString()),
+              const SizedBox(height: 8),
+              Text(appointment.time.toString()),
+              const SizedBox(height: 8),
+              Text(appointment.description),
+              const SizedBox(height: 24),
+              Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    context.go('/personal/edit/$id');
+                  },
+                  child: const Text('Edit'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/personal_scheduler/appointment_details_screen_test.dart
+++ b/test/features/personal_scheduler/appointment_details_screen_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:appointnew/features/personal_scheduler/appointment_details_screen.dart';
+import 'package:appointnew/features/personal_scheduler/appointments_provider.dart';
+import 'package:appointnew/features/personal_scheduler/domain/appointment.dart';
+
+void main() {
+  testWidgets('AppointmentDetailsScreen displays appointment data', (tester) async {
+    const testAppointment = Appointment(
+      id: '1',
+      title: 'Test Appointment',
+      date: '2023-01-01',
+      time: '10:00',
+      description: 'Description',
+    );
+
+    final container = ProviderContainer(overrides: [
+      appointmentsProvider('1').overrideWithValue(const AsyncValue.data(testAppointment)),
+    ]);
+
+    final router = GoRouter(
+      initialLocation: '/personal/details/1',
+      routes: [
+        GoRoute(
+          path: '/personal/details/:id',
+          builder: (context, state) => const AppointmentDetailsScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump();
+
+    expect(find.text('Test Appointment'), findsOneWidget);
+    expect(find.text('2023-01-01'), findsOneWidget);
+    expect(find.text('10:00'), findsOneWidget);
+    expect(find.text('Description'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add new appointment details screen
- include widget test for appointment details screen

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze .` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446d1086a483248c303c0a9adbb52f