### PR TITLE
Add appointment details screen and widget test

### DIFF
--- a/lib/features/personal_scheduler/appointment_details_screen.dart
+++ b/lib/features/personal_scheduler/appointment_details_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'appointments_provider.dart';
+import 'domain/appointment.dart';
+
+/// Screen showing details for a single [Appointment].
+class AppointmentDetailsScreen extends ConsumerWidget {
+  const AppointmentDetailsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final id = GoRouter.of(context).pathParameters['id'] ?? '';
+    final AsyncValue<Appointment> appointment =
+        ref.watch(appointmentsProvider(id));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Appointment Details')),
+      body: appointment.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('Error: \$error')),
+        data: (appt) {
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          appt.title,
+                          style: Theme.of(context).textTheme.headline6,
+                        ),
+                        const SizedBox(height: 8),
+                        Text('Date: \${appt.date.toLocal()}'),
+                        const SizedBox(height: 4),
+                        Text('Time: \${appt.time}'),
+                        const SizedBox(height: 12),
+                        Text(appt.description),
+                      ],
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () => context.push('/personal/edit/\$id'),
+                    child: const Text('Edit'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/personal_scheduler/appointments_provider.dart
+++ b/lib/features/personal_scheduler/appointments_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'domain/appointment.dart';
+
+final appointmentsProvider = FutureProvider.family<Appointment, String>((ref, id) async {
+  // Replace with real data fetching logic.
+  throw UnimplementedError();
+});

--- a/lib/features/personal_scheduler/domain/appointment.dart
+++ b/lib/features/personal_scheduler/domain/appointment.dart
@@ -1,0 +1,15 @@
+class Appointment {
+  final String id;
+  final String title;
+  final DateTime date;
+  final String time;
+  final String description;
+
+  Appointment({
+    required this.id,
+    required this.title,
+    required this.date,
+    required this.time,
+    required this.description,
+  });
+}

--- a/lib/features/personal_scheduler/personal_home_screen.dart
+++ b/lib/features/personal_scheduler/personal_home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class PersonalHomeScreen extends StatelessWidget {
+  const PersonalHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Personal Home')),
+      body: const Center(child: Text('Home')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,11 @@ dependencies:
   flutter_riverpod: ^2.0.0
   firebase_core: ^2.10.0
   firebase_auth: ^4.3.0
+  go_router: ^6.5.0
 
 flutter:
   uses-material-design: true
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter

--- a/test/features/personal_scheduler/appointment_details_screen_test.dart
+++ b/test/features/personal_scheduler/appointment_details_screen_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:appointnew/features/personal_scheduler/appointment_details_screen.dart';
+import 'package:appointnew/features/personal_scheduler/appointments_provider.dart';
+import 'package:appointnew/features/personal_scheduler/domain/appointment.dart';
+
+void main() {
+  testWidgets('Appointment details display', (tester) async {
+    final testAppointment = Appointment(
+      id: '1',
+      title: 'Test Title',
+      date: DateTime(2023, 1, 1),
+      time: '10:00 AM',
+      description: 'Test Description',
+    );
+
+    final container = ProviderContainer(overrides: [
+      appointmentsProvider.overrideWithProvider(
+        (id) => FutureProvider<Appointment>((ref) async => testAppointment),
+      ),
+    ]);
+
+    final router = GoRouter(
+      initialLocation: '/personal/details/1',
+      routes: [
+        GoRoute(
+          path: '/personal/details/:id',
+          builder: (context, state) => const AppointmentDetailsScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test Title'), findsOneWidget);
+    expect(find.text('10:00 AM'), findsOneWidget);
+    expect(find.text('Test Description'), findsOneWidget);
+    expect(find.text('Edit'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add go_router to pubspec
- stub appointment domain, provider and home screen
- implement AppointmentDetailsScreen to show appointment info
- add widget test for AppointmentDetailsScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844713e96cc83249871009a9894cd96