### PR TITLE
Add appointment edit screen

### DIFF
--- a/lib/features/personal_scheduler/appointment_edit_screen.dart
+++ b/lib/features/personal_scheduler/appointment_edit_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/models/appointment.dart';
+import '../../providers/appointments_provider.dart';
+
+class AppointmentEditScreen extends ConsumerWidget {
+  const AppointmentEditScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final id = GoRouterState.of(context).params['id'] ?? '';
+    final appointmentAsync = ref.watch(appointmentsProvider(id));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Appointment'),
+      ),
+      body: appointmentAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, stack) => Center(child: Text('Error: $err')),
+        data: (appointment) {
+          final titleController = TextEditingController(text: appointment.title);
+          final dateController = TextEditingController(text: appointment.date);
+          final timeController = TextEditingController(text: appointment.time);
+          final descController = TextEditingController(text: appointment.description);
+          final formKey = GlobalKey<FormState>();
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Form(
+              key: formKey,
+              child: ListView(
+                children: [
+                  TextFormField(
+                    controller: titleController,
+                    decoration: const InputDecoration(labelText: 'Title'),
+                    validator: (val) => val == null || val.isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: dateController,
+                    decoration: const InputDecoration(labelText: 'Date'),
+                    validator: (val) => val == null || val.isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: timeController,
+                    decoration: const InputDecoration(labelText: 'Time'),
+                    validator: (val) => val == null || val.isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: descController,
+                    decoration: const InputDecoration(labelText: 'Description'),
+                    maxLines: 3,
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: () async {
+                      if (!formKey.currentState!.validate()) return;
+                      final updated = Appointment(
+                        id: appointment.id,
+                        title: titleController.text,
+                        date: dateController.text,
+                        time: timeController.text,
+                        description: descController.text,
+                      );
+                      await ref
+                          .read(appointmentsProvider(id).notifier)
+                          .update(updated);
+                      if (context.mounted) {
+                        context.go('/personal/details/$id');
+                      }
+                    },
+                    child: const Text('Save'),
+                  )
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/test/features/personal_scheduler/appointment_edit_screen_test.dart
+++ b/test/features/personal_scheduler/appointment_edit_screen_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:appointnew/features/personal_scheduler/appointment_edit_screen.dart';
+import 'package:appointnew/core/models/appointment.dart';
+import 'package:appointnew/providers/appointments_provider.dart';
+
+void main() {
+  final testAppointment = Appointment(
+    id: '1',
+    title: 'Test',
+    date: '2023-01-01',
+    time: '10:00',
+    description: 'desc',
+  );
+
+  testWidgets('loads and displays appointment data', (tester) async {
+    final container = ProviderContainer(overrides: [
+      appointmentsProvider('1').overrideWithValue(AsyncValue.data(testAppointment)),
+    ]);
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/personal/edit/:id',
+          builder: (context, state) => const AppointmentEditScreen(),
+        ),
+      ],
+      initialLocation: '/personal/edit/1',
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    await tester.pump(); // loading
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump(); // loaded
+    expect(find.byType(TextFormField), findsNWidgets(4));
+    expect(find.text('Test'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add AppointmentEditScreen widget for editing appointments
- add widget test stub for AppointmentEditScreen

## Testing
- `dart format -o none --set-exit-if-changed lib/features/personal_scheduler/appointment_edit_screen.dart test/features/personal_scheduler/appointment_edit_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844821cf84083249fe85adcb28c2f3b