### PR TITLE
Add appointment edit screen

### DIFF
--- a/lib/features/personal_scheduler/appointment_edit_screen.dart
+++ b/lib/features/personal_scheduler/appointment_edit_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'domain/appointment.dart';
+import 'data/appointments_provider.dart';
+
+class AppointmentEditScreen extends ConsumerWidget {
+  AppointmentEditScreen({Key? key}) : super(key: key);
+
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final id = GoRouterState.of(context).params['id']!;
+    final appointmentAsync = ref.watch(appointmentsProvider(id));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Appointment')),
+      body: appointmentAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => Center(child: Text('Error: $e')),
+        data: (appointment) {
+          String title = appointment.title;
+          DateTime date = appointment.date;
+          TimeOfDay time = appointment.time;
+          String description = appointment.description;
+
+          TimeOfDay _parseTime(String value, TimeOfDay fallback) {
+            final parts = value.split(':');
+            if (parts.length >= 2) {
+              final h = int.tryParse(parts[0]);
+              final m = int.tryParse(parts[1]);
+              if (h != null && m != null) {
+                return TimeOfDay(hour: h, minute: m);
+              }
+            }
+            return fallback;
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextFormField(
+                    initialValue: appointment.title,
+                    decoration: const InputDecoration(labelText: 'Title'),
+                    onSaved: (v) => title = v ?? '',
+                    validator: (v) =>
+                        v == null || v.isEmpty ? 'Title required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    initialValue:
+                        appointment.date.toIso8601String().split('T').first,
+                    decoration: const InputDecoration(labelText: 'Date'),
+                    onSaved: (v) =>
+                        date = DateTime.tryParse(v ?? '') ?? appointment.date,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    initialValue: appointment.time.format(context),
+                    decoration: const InputDecoration(labelText: 'Time'),
+                    onSaved: (v) => time =
+                        v != null ? _parseTime(v, appointment.time) : time,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    initialValue: appointment.description,
+                    decoration: const InputDecoration(labelText: 'Description'),
+                    maxLines: 3,
+                    onSaved: (v) => description = v ?? '',
+                  ),
+                  const Spacer(),
+                  ElevatedButton(
+                    onPressed: () async {
+                      if (_formKey.currentState!.validate()) {
+                        _formKey.currentState!.save();
+                        final updated = appointment.copyWith(
+                          title: title,
+                          date: date,
+                          time: time,
+                          description: description,
+                        );
+                        await ref
+                            .read(appointmentsRepositoryProvider)
+                            .update(updated);
+                        if (context.mounted) context.pop();
+                      }
+                    },
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/personal_scheduler/data/appointments_provider.dart
+++ b/lib/features/personal_scheduler/data/appointments_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import '../domain/appointment.dart';
+
+class AppointmentsRepository {
+  final Map<String, Appointment> _storage = {};
+
+  AppointmentsRepository() {
+    final now = DateTime.now();
+    _storage['1'] = Appointment(
+      id: '1',
+      title: 'Test Appointment',
+      date: DateTime(now.year, now.month, now.day),
+      time: TimeOfDay(hour: now.hour, minute: now.minute),
+      description: 'Demo description',
+    );
+  }
+
+  Future<Appointment> fetchById(String id) async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    return _storage[id]!;
+  }
+
+  Future<void> update(Appointment appointment) async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    _storage[appointment.id] = appointment;
+  }
+}
+
+final appointmentsRepositoryProvider = Provider<AppointmentsRepository>((ref) {
+  return AppointmentsRepository();
+});
+
+final appointmentsProvider =
+    FutureProvider.family<Appointment, String>((ref, id) async {
+  final repo = ref.watch(appointmentsRepositoryProvider);
+  return repo.fetchById(id);
+});

--- a/lib/features/personal_scheduler/domain/appointment.dart
+++ b/lib/features/personal_scheduler/domain/appointment.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class Appointment {
+  final String id;
+  final String title;
+  final DateTime date;
+  final TimeOfDay time;
+  final String description;
+
+  Appointment({
+    required this.id,
+    required this.title,
+    required this.date,
+    required this.time,
+    required this.description,
+  });
+
+  Appointment copyWith({
+    String? id,
+    String? title,
+    DateTime? date,
+    TimeOfDay? time,
+    String? description,
+  }) {
+    return Appointment(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      date: date ?? this.date,
+      time: time ?? this.time,
+      description: description ?? this.description,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter_riverpod: ^2.0.0
   firebase_core: ^2.10.0
   firebase_auth: ^4.3.0
+  go_router: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/test/features/personal_scheduler/appointment_edit_screen_test.dart
+++ b/test/features/personal_scheduler/appointment_edit_screen_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:appointnew/features/personal_scheduler/appointment_edit_screen.dart';
+import 'package:appointnew/features/personal_scheduler/data/appointments_provider.dart';
+import 'package:appointnew/features/personal_scheduler/domain/appointment.dart';
+
+void main() {
+  testWidgets('edit screen shows appointment data', (tester) async {
+    final testAppointment = Appointment(
+      id: '1',
+      title: 'Meeting',
+      date: DateTime(2023, 1, 1),
+      time: const TimeOfDay(hour: 10, minute: 30),
+      description: 'Discuss project',
+    );
+
+    final router = GoRouter(
+      initialLocation: '/personal/edit/1',
+      routes: [
+        GoRoute(
+          path: '/personal/edit/:id',
+          builder: (context, state) => AppointmentEditScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appointmentsProvider.overrideWithProvider(
+            (id) => FutureProvider((ref) async => testAppointment),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextFormField, 'Meeting'), findsOneWidget);
+    expect(find.text('Save'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add Appointment domain model
- add appointments repository and provider
- add appointment editing screen with form
- add widget test stub for edit screen
- declare go_router dependency

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze .` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844852d47108324a0152b98203d7623