### PR TITLE
Implement Firestore appointments repository

### DIFF
--- a/lib/features/personal_scheduler/appointments_provider.dart
+++ b/lib/features/personal_scheduler/appointments_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'data/appointments_repository.dart';
+import 'domain/appointment.dart';
+
+final appointmentsRepositoryProvider =
+    Provider<AppointmentsRepository>((ref) => AppointmentsRepository());
+
+final appointmentsProvider =
+    StreamProvider<List<Appointment>>((ref) {
+  final repo = ref.watch(appointmentsRepositoryProvider);
+  return repo.watchUpcoming();
+});
+

--- a/lib/features/personal_scheduler/data/appointments_repository.dart
+++ b/lib/features/personal_scheduler/data/appointments_repository.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../domain/appointment.dart';
+
+class AppointmentsRepository {
+  AppointmentsRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _collection =>
+      _firestore.collection('appointments');
+
+  Stream<List<Appointment>> watchUpcoming() {
+    return _collection
+        .where('startTime', isGreaterThan: Timestamp.now())
+        .orderBy('startTime')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => Appointment.fromJson(doc.data(), doc.id))
+            .toList());
+  }
+
+  Future<List<Appointment>> fetchUpcoming() async {
+    final snapshot = await _collection
+        .where('startTime', isGreaterThan: Timestamp.now())
+        .orderBy('startTime')
+        .get();
+    return snapshot.docs
+        .map((doc) => Appointment.fromJson(doc.data(), doc.id))
+        .toList();
+  }
+
+  Future<Appointment> fetchById(String id) async {
+    final doc = await _collection.doc(id).get();
+    final data = doc.data();
+    if (data == null) {
+      throw StateError('Appointment not found');
+    }
+    return Appointment.fromJson(data, doc.id);
+  }
+
+  Future<void> save(Appointment appointment) async {
+    await _collection.doc(appointment.id).set(appointment.toJson());
+  }
+}
+

--- a/lib/features/personal_scheduler/domain/appointment.dart
+++ b/lib/features/personal_scheduler/domain/appointment.dart
@@ -1,0 +1,38 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Appointment {
+  final String id;
+  final String title;
+  final DateTime startTime;
+  final DateTime? endTime;
+  final String? description;
+
+  Appointment({
+    required this.id,
+    required this.title,
+    required this.startTime,
+    this.endTime,
+    this.description,
+  });
+
+  factory Appointment.fromJson(Map<String, dynamic> json, String id) {
+    return Appointment(
+      id: id,
+      title: json['title'] as String? ?? '',
+      startTime: (json['startTime'] as Timestamp).toDate(),
+      endTime: json['endTime'] != null
+          ? (json['endTime'] as Timestamp).toDate()
+          : null,
+      description: json['description'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'startTime': Timestamp.fromDate(startTime),
+      'endTime': endTime != null ? Timestamp.fromDate(endTime!) : null,
+      'description': description,
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,10 @@ dependencies:
   flutter_riverpod: ^2.0.0
   firebase_core: ^2.10.0
   firebase_auth: ^4.3.0
+  cloud_firestore: ^4.8.0
+
+dev_dependencies:
+  fake_cloud_firestore: ^1.3.0
 
 flutter:
   uses-material-design: true

--- a/test/features/personal_scheduler/appointments_repository_test.dart
+++ b/test/features/personal_scheduler/appointments_repository_test.dart
@@ -1,0 +1,26 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:appointnew/features/personal_scheduler/data/appointments_repository.dart';
+import 'package:appointnew/features/personal_scheduler/domain/appointment.dart';
+
+void main() {
+  group('AppointmentsRepository', () {
+    test('fetchUpcoming returns appointments from firestore', () async {
+      final firestore = FakeFirebaseFirestore();
+      final futureDate = DateTime.now().add(const Duration(days: 1));
+      await firestore.collection('appointments').doc('1').set({
+        'title': 'Test',
+        'startTime': Timestamp.fromDate(futureDate),
+      });
+
+      final repo = AppointmentsRepository(firestore: firestore);
+      final results = await repo.fetchUpcoming();
+
+      expect(results, hasLength(1));
+      expect(results.first.title, 'Test');
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `Appointment` model with Firestore serialization
- implement `AppointmentsRepository` for Firestore CRUD
- provide `appointmentsProvider` stream using Riverpod
- add widget test stub for repository
- add Firestore packages to `pubspec.yaml`

## Testing
- `flutter test test/features/personal_scheduler/appointments_repository_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448996fff0832492ba35f83fb45192