### PR TITLE
Add AppointmentsRepository with Firestore integration

### DIFF
--- a/lib/features/personal_scheduler/data/appointments_repository.dart
+++ b/lib/features/personal_scheduler/data/appointments_repository.dart
@@ -1,0 +1,45 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../domain/appointment.dart';
+
+class AppointmentsRepository {
+  final _collection = FirebaseFirestore.instance.collection('appointments');
+
+  Stream<List<Appointment>> watchAppointments() {
+    return _collection.snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => Appointment.fromJson(doc.data()))
+          .toList();
+    });
+  }
+
+  Future<Appointment> fetchAppointment(String id) async {
+    try {
+      final doc = await _collection.doc(id).get();
+      final data = doc.data();
+      if (data == null) throw Exception('Appointment not found');
+      return Appointment.fromJson(data);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> saveAppointment(Appointment appointment) async {
+    try {
+      await _collection.doc(appointment.id).set(appointment.toJson());
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> deleteAppointment(String id) async {
+    try {
+      await _collection.doc(id).delete();
+    } catch (e) {
+      rethrow;
+    }
+  }
+}
+
+final appointmentsRepositoryProvider =
+    Provider<AppointmentsRepository>((ref) => AppointmentsRepository());


### PR DESCRIPTION
## Summary
- add `AppointmentsRepository` with Firestore CRUD methods
- expose repository with a Riverpod provider

## Testing
- `bash setup.sh` *(fails: 403 Forbidden)*
- `bash setup_flutter.sh` *(fails: Flutter SDK not found)*
- `dart format --output=none --set-exit-if-changed lib/features/personal_scheduler/data/appointments_repository.dart` *(fails: command not found)*
- `dart analyze .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448fce85c8832492bedb649685821f