### PR TITLE
Implement appointments repository

### DIFF
--- a/lib/features/personal_scheduler/data/appointments_repository.dart
+++ b/lib/features/personal_scheduler/data/appointments_repository.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../domain/appointment.dart';
+
+class AppointmentsRepository {
+  final CollectionReference<Map<String, dynamic>> _collection =
+      FirebaseFirestore.instance.collection('appointments');
+
+  Stream<List<Appointment>> watchAppointments() {
+    try {
+      return _collection.snapshots().map((snapshot) =>
+          snapshot.docs.map((doc) => Appointment.fromJson(doc.data())).toList());
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<Appointment> fetchAppointment(String id) async {
+    try {
+      final doc = await _collection.doc(id).get();
+      if (!doc.exists) {
+        throw Exception('Appointment not found');
+      }
+      return Appointment.fromJson(doc.data()!);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> saveAppointment(Appointment appointment) async {
+    try {
+      await _collection.doc(appointment.id).set(appointment.toJson());
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> deleteAppointment(String id) async {
+    try {
+      await _collection.doc(id).delete();
+    } catch (e) {
+      rethrow;
+    }
+  }
+}
+
+final appointmentsRepositoryProvider =
+    Provider<AppointmentsRepository>((ref) => AppointmentsRepository());


### PR DESCRIPTION
## Summary
- implement `AppointmentsRepository` for Firestore access
- provide Riverpod `appointmentsRepositoryProvider`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68449789884483249807a7c6332885b0